### PR TITLE
feat: added RDS subnet group

### DIFF
--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -90,3 +90,14 @@ module "security_groups" {
   vpc_main_id = aws_vpc.vpc_main.id
   vpc_cidr    = var.vpc_cidr
 }
+
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name        = "${var.environment}_rds_subnet_group"
+  description = "RDS subnet group that points to our private subnets"
+  subnet_ids  = aws_subnet.private_subnets[*].id
+
+  tags = {
+    Name        = "${var.environment}_rds_subnet_group"
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -62,3 +62,8 @@ output "rds_security_group_id" {
   description = "RDS security group id"
   value       = module.security_groups.rds_security_group_id
 }
+
+output "rds_subnet_group_name" {
+  description = "Name of the RDS subnet group"
+  value       = aws_db_subnet_group.rds_subnet_group.name
+}


### PR DESCRIPTION
Q&A + explanations of how things work

Do we need to create a DB subnet group? Even though we already made a VPC with subnets?
		- **answer:** yes, sort of
			- sort of == 
				- DB subnet groups simply tell RDS which existing private subnet to use
				- you won't be creating new subnets within your VPC. however, you will need to create a DB subnet group that points to your existing subnets
			- Why We Need a DB Subnet Group
				- A DB subnet group is a collection of subnets (typically private) that you designate for your RDS instances[Working with a DB instance in a VPC -  AWS Docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html)
				- RDS uses this group to choose a subnet and IP address for your database instance[Working with a DB instance in a VPC -  AWS Docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html)
				- The DB instance will use the Availability Zone that contains the chosen subnet[Working with a DB instance in a VPC -  AWS Docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html)
			- Requirements
				- Must include subnets in at least two Availability Zones[3](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html)
				- Should use private subnets for better security[6](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Tutorials.WebServerDB.CreateVPC.html)
				- Needs to be created within our existing VPC[3](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html)
			- Best Practice
				- Create a DB subnet group that:
					- Uses the private subnets we already created in our VPC
					- Spans multiple AZs for high availability
					- Enables future Multi-AZ deployment capability[6](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Tutorials.WebServerDB.CreateVPC.html)